### PR TITLE
Fix triangulation argument bug

### DIFF
--- a/fun_with_maps/core/point_generation.py
+++ b/fun_with_maps/core/point_generation.py
@@ -168,17 +168,19 @@ class PointGenerator:
 
             print(f"Generating {k} points using triangulation method...")
 
-            # Get polygon coordinates
+            # Create triangulation from the polygon geometry
+            # shapely.ops.triangulate expects a geometry object rather than a
+            # list of coordinates. The previous implementation incorrectly
+            # passed only the coordinate list which caused a TypeError when the
+            # function was executed.  We now always pass the polygon geometry
+            # directly so triangulation works as expected for both Polygon and
+            # MultiPolygon geometries.
             if hasattr(geometry, "exterior"):
-                # Single Polygon
-                coords = list(geometry.exterior.coords)
+                polygon_for_triangulation = geometry
             else:
-                # MultiPolygon - use the largest polygon
-                largest_poly = max(geometry.geoms, key=lambda p: p.area)
-                coords = list(largest_poly.exterior.coords)
+                polygon_for_triangulation = max(geometry.geoms, key=lambda p: p.area)
 
-            # Create triangulation
-            triangles = triangulate(coords)
+            triangles = triangulate(polygon_for_triangulation)
 
             # Calculate areas of triangles that are inside the polygon
             valid_triangles = []

--- a/tests/test_point_generation.py
+++ b/tests/test_point_generation.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 from shapely.geometry import Point, Polygon
+from unittest.mock import patch
 
 from fun_with_maps.core.point_generation import generate_random_points_in_polygon
 
@@ -55,6 +56,19 @@ class TestGenerateRandomPointsInPolygon:
         polygon_geom = sample_country.iloc[0].geometry
         for _, row in result.iterrows():
             assert polygon_geom.contains(row.geometry)
+
+    def test_triangulation_uses_polygon_geometry(self, sample_country):
+        """Ensure triangulation is called with a polygon geometry object."""
+        with patch("shapely.ops.triangulate") as mock_triangulate:
+            mock_triangulate.return_value = [sample_country.iloc[0].geometry]
+
+            generate_random_points_in_polygon(
+                sample_country, 1, method="triangulation"
+            )
+
+            assert mock_triangulate.called
+            arg = mock_triangulate.call_args[0][0]
+            assert hasattr(arg, "geom_type")
 
     def test_generate_points_invalid_method(self, sample_country):
         """Test with invalid method parameter."""


### PR DESCRIPTION
## Summary
- fix triangulation by passing polygon geometry instead of raw coords
- ensure triangulation helper receives a polygon

## Testing
- `pre-commit run --files fun_with_maps/core/point_generation.py tests/test_point_generation.py` *(fails: command not found)*
- `pytest tests/test_point_generation.py::TestGenerateRandomPointsInPolygon::test_triangulation_uses_polygon_geometry -q` *(fails: ModuleNotFoundError: No module named 'geopandas')*

------
https://chatgpt.com/codex/tasks/task_b_68601b29f68c832abbe60fa7dcbc7bf0