### PR TITLE
Implement CLI enhancements and PDF control

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from scripts.cli import cli
+
+
+def test_list_countries_command(mock_world_data):
+    runner = CliRunner()
+    with patch("scripts.cli.fetch_world_map") as mock_fetch:
+        mock_fetch.return_value = mock_world_data
+        result = runner.invoke(cli, ["list-countries"])
+        assert result.exit_code == 0
+        for country in mock_world_data["NAME"]:
+            assert country in result.output
+
+
+def test_closest_countries_command(mock_world_data):
+    runner = CliRunner()
+    with patch("scripts.cli.fetch_world_map") as mock_fetch, patch(
+        "scripts.cli.get_country_polygon"
+    ) as mock_get_polygon, patch(
+        "scripts.cli.find_multiple_closest_countries"
+    ) as mock_find:
+        mock_fetch.return_value = mock_world_data
+        mock_polygon = mock_world_data.iloc[[0]]
+        mock_get_polygon.return_value = mock_polygon
+        mock_find.return_value = [("A", 0.0), ("B", 1.0), ("C", 2.0)]
+
+        result = runner.invoke(cli, ["closest-countries", "TestCountryA", "--n", "2"])
+        assert result.exit_code == 0
+        assert "B" in result.output
+        assert "C" in result.output

--- a/tests/test_main_script.py
+++ b/tests/test_main_script.py
@@ -1,3 +1,4 @@
+# flake8: noqa
 """
 Tests for the main script functionality.
 
@@ -5,18 +6,19 @@ This module contains tests to ensure that the main script works correctly,
 including integration tests and tests for specific bug fixes.
 """
 
+import os
 import subprocess
 import sys
-import os
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 # Add the project root to the path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scripts.main import setup_country_analysis, voronoi_only_analysis
 from fun_with_maps.core.country_analysis import get_country_polygon
 from fun_with_maps.core.map_fetcher import fetch_world_map
+from scripts.main import setup_country_analysis, voronoi_only_analysis
 
 
 class TestMainScript:
@@ -24,36 +26,48 @@ class TestMainScript:
 
     def test_main_script_runs_without_error(self):
         """Test that the main script can be executed without crashing.
-        
+
         This specifically tests for the 'too many values to unpack' error
         that was occurring when get_country_polygon was incorrectly unpacked.
         """
-        script_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts", "main.py")
-        
+        script_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "scripts", "main.py"
+        )
+
         # Run the script with a test country
         try:
             result = subprocess.run(
                 [sys.executable, script_path, "--country", "Iran"],
                 capture_output=True,
                 text=True,
-                timeout=15  # 15 second timeout - enough to test core functionality
+                timeout=15,  # 15 second timeout - enough to test core functionality
             )
         except subprocess.TimeoutExpired as e:
             # If it times out, that's good - it means the script is running without crashing
             # Check the stderr for the specific errors we're testing for
             stderr_output = e.stderr.decode() if e.stderr else ""
             stdout_output = e.stdout.decode() if e.stdout else ""
-            
-            assert "too many values to unpack" not in stderr_output, f"Unpacking error occurred: {stderr_output}"
-            assert "No module named 'visualization'" not in stderr_output, f"Import error occurred: {stderr_output}"
-            
+
+            assert (
+                "too many values to unpack" not in stderr_output
+            ), f"Unpacking error occurred: {stderr_output}"
+            assert (
+                "No module named 'visualization'" not in stderr_output
+            ), f"Import error occurred: {stderr_output}"
+
             # If we see the script start processing, that's success
-            assert "Starting analysis for:" in stdout_output, "Script should start analysis"
+            assert (
+                "Starting analysis for:" in stdout_output
+            ), "Script should start analysis"
             return  # Test passes - script is running without critical errors
-        
+
         # If no timeout, check for critical errors
-        assert "too many values to unpack" not in result.stderr, f"Unpacking error occurred: {result.stderr}"
-        assert "No module named 'visualization'" not in result.stderr, f"Import error occurred: {result.stderr}"
+        assert (
+            "too many values to unpack" not in result.stderr
+        ), f"Unpacking error occurred: {result.stderr}"
+        assert (
+            "No module named 'visualization'" not in result.stderr
+        ), f"Import error occurred: {result.stderr}"
 
     def test_get_country_polygon_return_value(self):
         """Test that get_country_polygon returns the expected number of values."""
@@ -61,77 +75,91 @@ class TestMainScript:
         mock_world_map = MagicMock()
         mock_world_map.columns = ["NAME"]
         mock_world_map.__getitem__.return_value.str.contains.return_value = MagicMock()
-        mock_world_map.__getitem__.return_value.str.contains.return_value.__getitem__.return_value = MagicMock()
-        
+        mock_world_map.__getitem__.return_value.str.contains.return_value.__getitem__.return_value = (
+            MagicMock()
+        )
+
         # Mock a successful country match
         mock_country_data = MagicMock()
         mock_country_data.empty = False
         mock_country_data.iloc = [MagicMock()]
         mock_country_data.iloc[0] = {"NAME": "Iran"}
-        
-        with patch('fun_with_maps.core.country_analysis.get_country_polygon') as mock_get_country:
+
+        with patch(
+            "fun_with_maps.core.country_analysis.get_country_polygon"
+        ) as mock_get_country:
             mock_get_country.return_value = mock_country_data
-            
+
             result = get_country_polygon(mock_world_map, "Iran")
-            
+
             # The function should return exactly one value, not a tuple
-            assert not isinstance(result, tuple), "get_country_polygon should not return a tuple"
+            assert not isinstance(
+                result, tuple
+            ), "get_country_polygon should not return a tuple"
 
     def test_setup_country_analysis_unpacking_issue(self):
         """Test the specific unpacking issue in setup_country_analysis."""
-        with patch('scripts.main.fetch_world_map') as mock_fetch:
-            with patch('scripts.main.get_country_polygon') as mock_get_country:
-                with patch('scripts.main.visualize_country_polygon') as mock_visualize:
-                    
+        with patch("scripts.main.fetch_world_map") as mock_fetch:
+            with patch("scripts.main.get_country_polygon") as mock_get_country:
+                with patch("scripts.main.visualize_country_polygon") as mock_visualize:
                     # Mock the world map
                     mock_world_map = MagicMock()
                     mock_fetch.return_value = mock_world_map
-                    
+
                     # Mock get_country_polygon to return only one value (the actual behavior)
                     mock_country_gdf = MagicMock()
                     mock_country_gdf.iloc = [{"NAME": "Iran"}]
                     mock_get_country.return_value = mock_country_gdf
-                    
+
                     # This should not raise a "too many values to unpack" error
                     try:
                         result = setup_country_analysis("Iran")
                         # If it doesn't crash, that's good, but we need to check the fix
-                        assert len(result) == 3, "setup_country_analysis should return 3 values"
+                        assert (
+                            len(result) == 3
+                        ), "setup_country_analysis should return 3 values"
                     except ValueError as e:
                         if "too many values to unpack" in str(e):
-                            pytest.fail("setup_country_analysis has unpacking issue that needs to be fixed")
+                            pytest.fail(
+                                "setup_country_analysis has unpacking issue that needs to be fixed"
+                            )
                         else:
                             # Some other error, re-raise it
                             raise
 
     def test_voronoi_only_analysis_unpacking_issue(self):
         """Test the specific unpacking issue in voronoi_only_analysis."""
-        with patch('scripts.main.fetch_world_map') as mock_fetch:
-            with patch('scripts.main.get_country_polygon') as mock_get_country:
-                with patch('scripts.main.get_admin1_capitals') as mock_get_capitals:
-                    with patch('scripts.main.create_voronoi_analysis') as mock_create_voronoi:
-                        with patch('scripts.main.clear_plot_tracker') as mock_clear:
-                            with patch('scripts.main.set_country_info') as mock_set_info:
-                                
+        with patch("scripts.main.fetch_world_map") as mock_fetch:
+            with patch("scripts.main.get_country_polygon") as mock_get_country:
+                with patch("scripts.main.get_admin1_capitals") as mock_get_capitals:
+                    with patch(
+                        "scripts.main.create_voronoi_analysis"
+                    ) as mock_create_voronoi:
+                        with patch("scripts.main.clear_plot_tracker") as mock_clear:
+                            with patch(
+                                "scripts.main.set_country_info"
+                            ) as mock_set_info:
                                 # Mock the world map
                                 mock_world_map = MagicMock()
                                 mock_fetch.return_value = mock_world_map
-                                
+
                                 # Mock get_country_polygon to return only one value (the actual behavior)
                                 mock_country_gdf = MagicMock()
                                 mock_country_gdf.iloc = [{"NAME": "Iran"}]
                                 mock_get_country.return_value = mock_country_gdf
-                                
+
                                 # Mock capitals
                                 mock_get_capitals.return_value = MagicMock()
-                                
+
                                 # This should not raise a "too many values to unpack" error
                                 try:
                                     voronoi_only_analysis("Iran")
                                     # If it doesn't crash, the fix is working
                                 except ValueError as e:
                                     if "too many values to unpack" in str(e):
-                                        pytest.fail("voronoi_only_analysis has unpacking issue that needs to be fixed")
+                                        pytest.fail(
+                                            "voronoi_only_analysis has unpacking issue that needs to be fixed"
+                                        )
                                     else:
                                         # Some other error, re-raise it
                                         raise
@@ -139,59 +167,105 @@ class TestMainScript:
     def test_visualization_import_issue(self):
         """Test that the script can import visualization functions correctly."""
         # This tests for the ModuleNotFoundError: No module named 'visualization'
-        script_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts", "main.py")
-        
+        script_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "scripts", "main.py"
+        )
+
         # Run the script briefly to see if it gets past the import error
         try:
             result = subprocess.run(
                 [sys.executable, script_path, "--country", "Iran"],
                 capture_output=True,
                 text=True,
-                timeout=10  # Short timeout, just to test import works
+                timeout=10,  # Short timeout, just to test import works
             )
         except subprocess.TimeoutExpired as e:
             # If it times out, that means it got past the import error and is running
             # Check the stderr for any import errors that occurred before timeout
             stderr_output = e.stderr.decode() if e.stderr else ""
-            assert "No module named 'visualization'" not in stderr_output, f"Visualization import error: {stderr_output}"
+            assert (
+                "No module named 'visualization'" not in stderr_output
+            ), f"Visualization import error: {stderr_output}"
             return  # Test passes - script is running without import errors
-        
+
         # If no timeout, check for import errors
-        assert "No module named 'visualization'" not in result.stderr, f"Visualization import error: {result.stderr}"
+        assert (
+            "No module named 'visualization'" not in result.stderr
+        ), f"Visualization import error: {result.stderr}"
 
     def test_create_country_visualization_import(self):
         """Test that the create_country_visualization_with_colors function can be imported correctly."""
         # Test importing the function directly
         try:
-            from fun_with_maps.visualization.visualization import create_country_visualization_with_colors
+            from fun_with_maps.visualization.visualization import (
+                create_country_visualization_with_colors,
+            )
+
             # If we can import it, the function exists
-            assert callable(create_country_visualization_with_colors), "Function should be callable"
+            assert callable(
+                create_country_visualization_with_colors
+            ), "Function should be callable"
         except ImportError as e:
-            pytest.fail(f"Could not import create_country_visualization_with_colors: {e}")
+            pytest.fail(
+                f"Could not import create_country_visualization_with_colors: {e}"
+            )
 
     def test_country_analysis_import_issue(self):
         """Test that the script can import country_analysis functions correctly."""
         # This tests for the ModuleNotFoundError: No module named 'country_analysis'
         # that occurs in the TSP analysis section
-        script_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts", "main.py")
-        
+        script_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), "scripts", "main.py"
+        )
+
         # Test that the main script doesn't have import errors for country_analysis
         try:
             result = subprocess.run(
                 [sys.executable, script_path, "--country", "Iran"],
                 capture_output=True,
                 text=True,
-                timeout=20  # Enough time to get to TSP analysis
+                timeout=20,  # Enough time to get to TSP analysis
             )
         except subprocess.TimeoutExpired as e:
             # Check for the specific import error in stderr
             stderr_output = e.stderr.decode() if e.stderr else ""
-            assert "No module named 'country_analysis'" not in stderr_output, f"Country analysis import error: {stderr_output}"
+            assert (
+                "No module named 'country_analysis'" not in stderr_output
+            ), f"Country analysis import error: {stderr_output}"
             return  # Test passes if no import error
-        
+
         # If no timeout, check for import errors
-        assert "No module named 'country_analysis'" not in result.stderr, f"Country analysis import error: {result.stderr}"
+        assert (
+            "No module named 'country_analysis'" not in result.stderr
+        ), f"Country analysis import error: {result.stderr}"
+
+    def test_main_skip_pdf_flag(self):
+        """Ensure PDF generation can be skipped via flag."""
+        with patch("scripts.main.generate_pdf_report") as mock_pdf, patch(
+            "scripts.main.setup_country_analysis"
+        ) as mock_setup, patch("scripts.main.generate_and_visualize_points"), patch(
+            "scripts.main.analyze_closest_countries"
+        ), patch(
+            "scripts.main.create_colored_visualization"
+        ), patch(
+            "scripts.main.get_admin1_capitals"
+        ) as mock_caps, patch(
+            "scripts.main.create_voronoi_analysis"
+        ), patch(
+            "scripts.main.filter_capitals_to_largest_polygon"
+        ) as mock_filter, patch(
+            "scripts.main.solve_tsp_for_country"
+        ):
+            mock_setup.return_value = (MagicMock(), MagicMock(), "Testland")
+            mock_caps.return_value = MagicMock()
+            mock_filter.return_value = MagicMock()
+
+            from scripts.main import main
+
+            main("Testland", skip_pdf=True)
+
+            mock_pdf.assert_not_called()
 
 
 if __name__ == "__main__":
-    pytest.main([__file__]) 
+    pytest.main([__file__])

--- a/tests/test_pdf_generation.py
+++ b/tests/test_pdf_generation.py
@@ -1,0 +1,20 @@
+import os
+
+from fun_with_maps.utils import utils
+
+
+def test_generate_pdf_report_custom_path(tmp_path):
+    utils.clear_plot_tracker()
+    utils.set_country_info("Testland")
+    image_path = tmp_path / "img.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    utils._plot_tracker["plots"].append(
+        {"title": "t", "description": "d", "filepath": str(image_path)}
+    )
+
+    os.makedirs("docs", exist_ok=True)
+    pdf_path = os.path.join("docs", "Testland_analysis_report.pdf")
+    utils.generate_pdf_report(output_filename=pdf_path)
+
+    assert os.path.exists(pdf_path)
+    os.remove(pdf_path)


### PR DESCRIPTION
## Summary
- add option `--skip-pdf` in `scripts/main.py` and write reports to `docs`
- extend CLI with `list-countries` and `closest-countries` commands
- provide tests for CLI, PDF generation, and skip-pdf flag
- keep docs directory in repository

## Testing
- `pre-commit run --files scripts/cli.py scripts/main.py tests/test_cli_commands.py tests/test_main_script.py tests/test_pdf_generation.py`
- `pytest -q` *(fails: `pytest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860256f2aa0832ab29214c27046f680