### PR TITLE
Serve static frontend index

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,8 @@
 import random
 from pathlib import Path
 
-from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import FastAPI
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -175,23 +175,13 @@ def choose_country():
 
 
 @app.get("/", response_class=HTMLResponse)
-async def read_index(request: Request):
-    country, hints, image_path = choose_country()
-    game_data = {"country": country, "valid_countries": available_countries}
-    return templates.TemplateResponse(
-        "index.html",
-        {
-            "request": request,
-            "country": country,
-            "hints": hints,
-            "valid_countries": available_countries,
-            "game_data": game_data,
-            "image_path": image_path,
-        },
-    )
+async def read_index():
+    """Serve the static index page."""
+    index_file = BASE_DIR / "static" / "index.html"
+    return FileResponse(index_file)
 
 
-@app.get("/new-game")
+@app.get("/api/new-game")
 async def new_game():
     """Get a new random country and hints for a fresh game."""
     country, hints, image_path = choose_country()

--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Guess the Country - Fun with Maps</title>
+    <link rel="stylesheet" href="/static/style.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🗺️ Guess the Country</h1>
+            <p class="subtitle">Test your geographical knowledge!</p>
+        </header>
+        <main>
+            <div id="game-interface" class="game-section">
+                <div class="question-mark">
+                    <i class="fas fa-question-circle"></i>
+                </div>
+                <h2>Guess the Country</h2>
+                <div class="image-section">
+                    <div id="country-image" class="image-container hidden">
+                        <img src="" alt="" id="main-image" style="display: none;">
+                    </div>
+                </div>
+                <div id="hints-section" class="hints">
+                    <div class="hint-container">
+                        <div class="hint revealed" id="hint-1"></div>
+                        <div class="hint" id="hint-2"></div>
+                        <div class="hint" id="hint-3"></div>
+                        <div class="hint" id="hint-4"></div>
+                    </div>
+                </div>
+                <div class="input-section">
+                    <input type="text" id="country-input" placeholder="Enter country name..." maxlength="50" list="countries-list">
+                    <datalist id="countries-list"></datalist>
+                    <div id="feedback" class="feedback" style="display:none;"></div>
+                    <button id="submit-btn" type="button">
+                        <i class="fas fa-check"></i> Submit
+                    </button>
+                </div>
+                <div id="congratulations" class="congratulations" style="display: none;">
+                    <h3>🎉 Congratulations! 🎉</h3>
+                    <p>You guessed correctly!</p>
+                </div>
+                <div id="game-over" class="game-over" style="display: none;">
+                    <h3>😞 Game Over</h3>
+                    <p>You've made 4 incorrect guesses.</p>
+                    <button id="restart-btn" class="restart-button">Play Again</button>
+                </div>
+            </div>
+            <div id="celebration" class="celebration">
+                <div class="colorful-boxes">
+                    <div class="box box-1"></div>
+                    <div class="box box-2"></div>
+                    <div class="box box-3"></div>
+                    <div class="box box-4"></div>
+                    <div class="box box-5"></div>
+                    <div class="box box-6"></div>
+                    <div class="box box-7"></div>
+                    <div class="box box-8"></div>
+                </div>
+                <div class="success-message">
+                    <h2>🎉 Amazing! 🎉</h2>
+                    <p>You discovered <span id="country-name"></span>!</p>
+                </div>
+            </div>
+        </main>
+        <footer>
+            <p>Part of Fun with Maps Project</p>
+        </footer>
+    </div>
+    <script>window.GAME_DATA = null;</script>
+    <script src="/static/script.js"></script>
+</body>
+</html>

--- a/backend/static/script.js
+++ b/backend/static/script.js
@@ -279,7 +279,7 @@ class CountryGuessingGame {
 
         try {
             // Fetch new game data from backend
-            const response = await fetch('/new-game');
+            const response = await fetch('/api/new-game');
             const newGameData = await response.json();
 
             console.log('New game data:', newGameData);
@@ -371,7 +371,16 @@ class CountryGuessingGame {
 }
 
 // Initialize the game when the page loads
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+    if (!window.GAME_DATA) {
+        try {
+            const resp = await fetch('/api/new-game');
+            window.GAME_DATA = await resp.json();
+        } catch (error) {
+            console.error('Error fetching initial game data:', error);
+            window.GAME_DATA = {};
+        }
+    }
     window.game = new CountryGuessingGame();
 });
 

--- a/frontend/src/Game.jsx
+++ b/frontend/src/Game.jsx
@@ -10,7 +10,7 @@ export default function Game() {
   const [won, setWon] = useState(false);
 
   useEffect(() => {
-    fetch('/new-game')
+    fetch('/api/new-game')
       .then((r) => r.json())
       .then((data) => {
         setCountry(data.country);


### PR DESCRIPTION
## Summary
- serve `backend/static/index.html` from the FastAPI root endpoint
- mount static files and images in `backend/main.py`
- move `/new-game` endpoint to `/api/new-game`
- fetch the new API route from frontend code
- dynamically load game data in `backend/static/script.js`
- adjust backend tests for new behaviour

## Testing
- `pre-commit run --files backend/main.py backend/static/script.js backend/static/index.html frontend/src/Game.jsx tests/test_backend.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6861463a5174832ab9d42a190b1a92cf