### PR TITLE
Add tests for new-game endpoint and React components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ ENV/
 *.log
 files_to_delete.log
 frontend/node_modules/
+frontend/test-results/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.53.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@vitejs/plugin-react": "^4.6.0",
@@ -936,6 +937,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2255,6 +2272,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.53.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@vitejs/plugin-react": "^4.6.0",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,14 @@
+// @ts-check
+import { defineConfig } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexPath = join(__dirname, '..', 'backend', 'static', 'index.html');
+
+export default defineConfig({
+  testDir: './tests',
+  use: {
+    baseURL: `file://${indexPath}`,
+  },
+});

--- a/frontend/src/Game.test.jsx
+++ b/frontend/src/Game.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import Game from './Game';
+
+function mockApi(data) {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(data) })
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('fetches hints on mount', async () => {
+  mockApi({ country: 'France', hints: ['a', 'b'] });
+  render(<Game />);
+  const list = await screen.findByTestId('hint-list');
+  expect(list.children).toHaveLength(2);
+});
+
+test('shows celebration after correct guess', async () => {
+  mockApi({ country: 'France', hints: [] });
+  render(<Game />);
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+  const input = screen.getByPlaceholderText(/your guess/i);
+  fireEvent.change(input, { target: { value: 'France' } });
+  fireEvent.click(screen.getByText('Guess'));
+
+  expect(screen.getByTestId('celebration')).toBeInTheDocument();
+});

--- a/frontend/tests/basic.spec.js
+++ b/frontend/tests/basic.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+// Basic smoke test to ensure app loads
+
+test('index page has header', async ({ page, baseURL }) => {
+  await page.goto(baseURL);
+  await expect(page.locator('h1')).toHaveText(/guess the country/i);
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,5 +12,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './setupTests.js',
     globals: true,
+    include: ['src/**/*.{test,spec}.{js,jsx}'],
+    exclude: ['tests/**'],
   },
 });

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -36,3 +36,32 @@ class TestBackend:
     def test_submit_endpoint_removed(self):
         response = client.post("/submit", data={"text": "hello"})
         assert response.status_code == 404
+
+    def test_api_new_game_no_data(self):
+        """Return empty values when no world data is available."""
+        with patch.object(backend, "fetch_world_map", return_value=None):
+            backend.data_loaded = False
+            response = client.get("/api/new-game")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["country"] is None
+            assert data["hints"] == []
+            assert data["valid_countries"] == []
+            assert data["image_path"] is None
+
+    def test_api_new_game_with_image(self, mock_world_data):
+        """Ensure image path from helper is included in response."""
+        with patch.object(
+            backend, "fetch_world_map", return_value=mock_world_data
+        ), patch.object(
+            backend.random, "choice", return_value="United States"
+        ), patch.object(
+            backend, "get_country_image_path", return_value="/images/US/test.png"
+        ), patch.object(
+            backend, "find_multiple_closest_countries", return_value=[("Canada", 1.0)]
+        ):
+            backend.data_loaded = False
+            response = client.get("/api/new-game")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["image_path"] == "/images/US/test.png"


### PR DESCRIPTION
## Summary
- add backend tests covering `/api/new-game` edge cases
- add React unit tests for `Game` component
- configure Vitest to ignore Playwright specs
- include a simple Playwright smoke test

## Testing
- `pytest -q`
- `npm test --silent`
- `npx playwright test`
- `pre-commit run --files tests/test_backend.py frontend/src/Game.test.jsx frontend/vite.config.js frontend/playwright.config.js frontend/tests/basic.spec.js`

------
https://chatgpt.com/codex/tasks/task_b_68614cef62a8832aa239789b96c4e27e