### PR TITLE
Update documentation and dev setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ These guidelines apply to the entire repository for Codex agents.
 - **Use pytest** for all testing.
 - **Open-source structure**: follow typical project organization and documentation.
 - **Pre-commit hooks**: ensure changes comply with pre-commit standards.
+  Install hooks with `pre-commit install` after setting up the dev requirements.
 
 ## File Management Rules
 - **NEVER delete files**. If a file should be removed, append its name to `files_to_be_deleted.txt` (one per line) for human review.
@@ -16,6 +17,12 @@ These guidelines apply to the entire repository for Codex agents.
 - Use the `debug/` directory for any debugging scripts or temporary code.
 
 ## Development Workflow
+Before starting work install dependencies using:
+```bash
+pip install -r requirements.txt -r requirements-dev.txt
+pip install -e .
+pre-commit install
+```
 ### Feature Development
 1. Implement the requested feature.
 2. Write comprehensive tests for the feature.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thank you for wanting to contribute to **Fun with Maps**!
+This project includes a CLI tool and a FastAPI backend. The following guidelines describe how to set up a development environment and how we expect contributions to be made.
+
+## Getting Started
+
+1. Fork and clone the repository.
+2. Install the runtime requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Install development tools and the package in editable mode:
+   ```bash
+   pip install -r requirements-dev.txt
+   pip install -e .
+   pre-commit install
+   ```
+4. Run the test suite to ensure everything is working:
+   ```bash
+   pytest
+   ```
+
+## Development Workflow
+
+- Make your changes in a feature branch.
+- Ensure `pre-commit` passes before committing:
+  ```bash
+  pre-commit run --files <changed files>
+  ```
+- Add or update tests for any code changes.
+- Verify the full test suite succeeds with `pytest`.
+- Open a pull request describing your changes.
+
+## Tools
+
+- **pre-commit**: automatically formats code and runs linters.
+- **pytest**: used for all tests.
+- **uv** *(optional)*: install dependencies quickly with
+  `./scripts/install_with_uv.sh`.
+
+We appreciate your contributions!

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 
-A comprehensive, modular geospatial analysis toolkit for working with world maps, finding closest countries to points, analyzing polygons, and generating random geographic points.
+A comprehensive, modular geospatial analysis toolkit for working with world maps.
+It ships with a command line interface as well as a small FastAPI backend used by
+the included web game.
 
 ## Features
 
@@ -26,7 +28,12 @@ git clone https://github.com/your-username/fun-with-maps.git
 cd fun-with-maps
 ```
 
-2. Install the package:
+2. Install the required packages:
+```bash
+pip install -r requirements.txt
+```
+
+3. (Optional) Install the CLI in editable mode:
 ```bash
 pip install -e .
 ```
@@ -35,7 +42,8 @@ pip install -e .
 
 For development with additional tools:
 ```bash
-pip install -e ".[dev]"
+pip install -r requirements.txt -r requirements-dev.txt
+pip install -e .
 pre-commit install
 ```
 
@@ -53,7 +61,7 @@ pip install uv  # one-time installation
 For development dependencies use:
 
 ```bash
-./scripts/install_with_uv.sh -e .[dev]
+./scripts/install_with_uv.sh -r requirements-dev.txt -e .
 pre-commit install
 ```
 
@@ -79,6 +87,17 @@ fun-with-maps-cli list-countries world.geojson
 fun-with-maps-cli get-admin1-capitals "Argentina"
 ```
 
+### Running the Backend Service
+
+The project includes a small FastAPI service that powers the web game in
+`frontend/`. Start it locally with:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+Once running, open <http://localhost:8000> to play the game.
+
 ### Using as a Python Package
 
 ```python
@@ -100,10 +119,10 @@ This project includes comprehensive test coverage using pytest. To run the tests
 
 ### Install Test Dependencies
 
-Test dependencies are included in `requirements.txt`, but you can install them specifically:
+Test dependencies are listed in `requirements-dev.txt`:
 
 ```bash
-pip install pytest pytest-cov
+pip install -r requirements-dev.txt
 ```
 
 ### Run All Tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+pytest>=7.0.0
+pytest-cov>=4.0.0
+pre-commit>=3.6.0
+black>=23.12.0
+isort>=5.13.0
+flake8>=7.0.0
+flake8-unused-arguments>=0.0.13
+flake8-import-order>=0.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,14 +14,4 @@ uvicorn>=0.24.0
 httpx>=0.25.0
 jinja2>=3.1.0
 python-multipart>=0.0.6
-# Testing dependencies
-pytest>=7.0.0
-pytest-cov>=4.0.0
-# Code quality and pre-commit dependencies
-pre-commit>=3.6.0
-black>=23.12.0
-isort>=5.13.0
-flake8>=7.0.0
-flake8-unused-arguments>=0.0.13
-flake8-import-order>=0.18.2
 scipy==1.15.3

--- a/scripts/install_with_uv.sh
+++ b/scripts/install_with_uv.sh
@@ -2,7 +2,7 @@
 # Install project requirements using uv.
 # Additional arguments are passed directly to 'uv pip install'.
 # Example:
-#   ./scripts/install_with_uv.sh             # install from requirements.txt
-#   ./scripts/install_with_uv.sh -e .[dev]   # editable install with dev extras
+#   ./scripts/install_with_uv.sh                   # install from requirements.txt
+#   ./scripts/install_with_uv.sh -r requirements-dev.txt -e .   # dev install
 set -e
 uv pip install -r requirements.txt "$@"


### PR DESCRIPTION
## Summary
- document CLI tool and backend in README
- describe installation with runtime vs dev requirements
- add a new CONTRIBUTING guide
- split requirements into user and dev files
- tweak `install_with_uv.sh` comments
- update AGENTS instructions

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md AGENTS.md requirements.txt requirements-dev.txt scripts/install_with_uv.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686152965320832a8b35f875a16a21cb